### PR TITLE
[DONT MERGE]: Fix/allow dot

### DIFF
--- a/src/pages/AddLiquidity/index.js
+++ b/src/pages/AddLiquidity/index.js
@@ -269,6 +269,8 @@ export default function AddLiquidity() {
 
   const { wethValue, daiValue, lastEditedField } = addLiquidityState
 
+  let wethValueFormatted = wethValue
+
   const [showBetaMessage, setShowBetaMessage] = useState(true)
   const [isWethApproved, setIsWethApproved] = useState(false)
   const [isDaiApproved, setIsDaiApproved] = useState(false)
@@ -278,8 +280,8 @@ export default function AddLiquidity() {
   const [upperBoundRate, setUpperBoundRate] = useState(null)
   const [metapoolBalanceWeth, setMetapoolBalanceWeth] = useState(null)
   const [metapoolBalanceDai, setMetapoolBalanceDai] = useState(null)
-  const [wethValueFormatted, setWethValueFormatted] = useState(null)
-  const [daiValueFormatted, setDaiValueFormatted] = useState(null)
+  // const [wethValueFormatted, setWethValueFormatted] = useState('')
+  const [daiValueFormatted, setDaiValueFormatted] = useState('')
   const [wethValueInput, setWethValueInput] = useState(null)
   const [daiValueInput, setDaiValueInput] = useState(null)
   const [estimatedAmountWeth, setEstimatedAmountWeth] = useState(null)
@@ -366,7 +368,7 @@ export default function AddLiquidity() {
             console.log("complete!")
             setIsAddLiquidityPending(false)
             setDaiValueFormatted('')
-            setWethValueFormatted('')
+            // setWethValueFormatted('')
             setDaiValueInput('')
             setWethValueInput('')
             window.location.href = '/remove-liquidity'
@@ -394,7 +396,7 @@ export default function AddLiquidity() {
     setUserEstimatedMint('')
     if (lowerBoundRate && upperBoundRate && metapoolBalanceDai && metapoolBalanceWeth) {
       if (lastEditedField === WETH_OP) {
-        setWethValueFormatted(wethValue)
+        // setWethValueFormatted(wethValue)
         setWethValueInput(wethValue)
         if (wethValue) {
           getPoolCurrentInfo(poolV3, gelatoPool, wethContract, daiContract).then((result) => {
@@ -466,7 +468,7 @@ export default function AddLiquidity() {
             });
           });
         } else {
-          setWethValueFormatted('')
+          // setWethValueFormatted('')
           setDaiValueFormatted('')
         }
       } else {
@@ -509,7 +511,7 @@ export default function AddLiquidity() {
                 if ((estimatedAmountWeth.sub(wethBalance)).gt(ethers.constants.Zero)) {
                   estimatedAmountWeth = wethBalance;
                 }
-                setWethValueFormatted(ethers.utils.formatEther(estimatedAmountWeth))
+                wethValueFormatted = ethers.utils.formatEther(estimatedAmountWeth)
                 setEstimatedAmountWeth(Number(ethers.utils.formatEther(r3.amount1)))
                 setEstimatedAmountDai(Number(ethers.utils.formatEther(estimatedAmountDai)))
                 setWethValueInput(ethers.utils.formatEther(estimatedAmountWeth));
@@ -541,7 +543,7 @@ export default function AddLiquidity() {
             });
           });
         } else {
-          setWethValueFormatted('')
+          // setWethValueFormatted('')
           setDaiValueFormatted('')
         }
       }


### PR DESCRIPTION
The problem why we cannot input values separated by `.` and only `,` is because we set the formatted values such as `wethValueFormatted` using react state instead of just instantiating them as constants like we do in the `ExchangePage` and all the other pages. Setting it as state will result in us passing a seamlessly different value to the `CurrencyInputPannel` which in turn updates the value stored in the `AddLiquidty` component to  `''` if we use a `dot` to input e.g. `0.1`. 

These gigantic useEffect statements where we do the formatting of the inputs have to be refactored anyways because they are unreadable, so lets do that and just instantiate the formatted variables are constants rather than setting them in state (a lot of unnecessary re-renders will be the result. Let me know if you need more info.